### PR TITLE
Remove turbolinks

### DIFF
--- a/StockApp/Gemfile
+++ b/StockApp/Gemfile
@@ -17,7 +17,6 @@ gem 'coffee-rails', '~> 4.1.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/StockApp/app/assets/javascripts/application.js
+++ b/StockApp/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/StockApp/app/models/company.rb
+++ b/StockApp/app/models/company.rb
@@ -5,7 +5,6 @@ class Company < ActiveRecord::Base
 		@found_companies = [] 
 	  @found_companies << where("name ILIKE ?", "#{prefix}%").order('name ASC')
 	  @found_companies << where("symbol ILIKE ?", "#{prefix}%").order('name ASC')
-    @found_companies
 	end
 
 	def self.graph_data(stock)

--- a/StockApp/app/views/companies/show.html.erb
+++ b/StockApp/app/views/companies/show.html.erb
@@ -13,6 +13,11 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js"></script>
   <script language="JavaScript">
+  
+  $(document).on('page:load', function(){
+    displayLineChart();
+	});
+
   function displayLineChart(labels, dataset) {  	
     var data = {
         labels: labels, 

--- a/StockApp/app/views/layouts/application.html.erb
+++ b/StockApp/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <title>StockApp</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
Removed turbolinks so that graph will load on first page visit instead of requiring page refresh. 
